### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 Mercury shows all queued up notifications at once, with an easy way to swipe through them (and will animate through them automatically if you don't touch any notifications for 3 seconds)
 
 ##Installation
-###Cocoapods Installation
+###CocoaPods Installation
 Mercury is available on CocoaPods. Just add the following to your project Podfile:
 
 ```
 pod 'Mercury'
 ```
 
-###Non-Cocoapods Installation
+###Non-CocoaPods Installation
 You can drop Mercury files directly into your project, or drag the Mercury project into your workspace.
 
 ###Usage


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
